### PR TITLE
add relevant definitions to the task 6, hw0

### DIFF
--- a/hw0.md
+++ b/hw0.md
@@ -194,6 +194,19 @@ foo char =
     case char == 'o' of
       True -> Just $ exp pi
       False -> Nothing
+
+-- not actually, but good enough for this task
+null :: [a] -> Bool
+null [] = True
+null _  = False
+
+mapMaybe          :: (a -> Maybe b) -> [a] -> [b]
+mapMaybe _ []     = []
+mapMaybe f (x:xs) =
+ let rs = mapMaybe f xs in
+ case f x of
+  Nothing -> rs
+  Just r  -> r:rs
 ```
 
 ### Задание 7


### PR DESCRIPTION
It might be not clear yet where to lookup definitions of functions, especially those of type classes, given they can be redefined. Minding that, it would make sense to include relevant to the task definitions in the task.